### PR TITLE
SSH key-pair fail at setup - added description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This work is modified from [cookiecutter-data-science](https://drivendata.github
 
 ### Requirements to use the cookiecutter template:
  - A [github](https://github.com/) account.
-   - Note that [account authentication via SSH key-pair](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh)) should be set up before initializing repositories using cookiecutter.
+   - Note that your account must be set up for [authentication via SSH key-pair](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh) before initializing repositories using cookiecutter.
  - [Conda package manager](https://conda.io/en/latest/)
  - [Cookiecutter Python package](http://cookiecutter.readthedocs.org/en/latest/installation.html)
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ $ ./scripts/setup.sh
 ```
 The script will prompt your github password to create the repository in your account.
 
+*NOTE* Remote access to GitHub is, by default, via an SSH key (see [here](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh)). If you do not have key-pair authentication set up from your current machine, this stage will fail when it tries to push the new repository to GitHub. So, you should either have a key-pair setup for the machine you are working on before invoking this setup (highly recommended) or, after this setup fails, change remote access to HTTP using `git remote set-url` (see [here](https://docs.github.com/en/enterprise/2.15/user/articles/changing-a-remotes-url). The repository can then be pushed to GitHub in the usual way (`git push -u origin master`), entering your username and password each time. 
+
 Now configure the packages you will need (you can add more later) in the 'environment.yml' file and create a conda environment
 
 ```

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This work is modified from [cookiecutter-data-science](https://drivendata.github
 
 ### Requirements to use the cookiecutter template:
  - A [github](https://github.com/) account.
+   - Note that [account authentication via SSH key-pair](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh)) should be set up before initializing repositories using cookiecutter.
  - [Conda package manager](https://conda.io/en/latest/)
  - [Cookiecutter Python package](http://cookiecutter.readthedocs.org/en/latest/installation.html)
 
@@ -53,7 +54,7 @@ $ ./scripts/setup.sh
 ```
 The script will prompt your github password to create the repository in your account.
 
-*NOTE* Remote access to GitHub is, by default, via an SSH key (see [here](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh)). If you do not have key-pair authentication set up from your current machine, this stage will fail when it tries to push the new repository to GitHub. So, you should either have a key-pair setup for the machine you are working on before invoking this setup (highly recommended) or, after this setup fails, change remote access to HTTP using `git remote set-url` (see [here](https://docs.github.com/en/enterprise/2.15/user/articles/changing-a-remotes-url)). The repository can then be pushed to GitHub in the usual way (`git push -u origin master`), entering your username and password each time. 
+*NOTE* This step will fail when attempting to push the new repository to GitHub if you have not yet set up SSH key-pair authentication (see [here](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh)).
 
 Now configure the packages you will need (you can add more later) in the 'environment.yml' file and create a conda environment
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ $ ./scripts/setup.sh
 ```
 The script will prompt your github password to create the repository in your account.
 
-*NOTE* Remote access to GitHub is, by default, via an SSH key (see [here](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh)). If you do not have key-pair authentication set up from your current machine, this stage will fail when it tries to push the new repository to GitHub. So, you should either have a key-pair setup for the machine you are working on before invoking this setup (highly recommended) or, after this setup fails, change remote access to HTTP using `git remote set-url` (see [here](https://docs.github.com/en/enterprise/2.15/user/articles/changing-a-remotes-url). The repository can then be pushed to GitHub in the usual way (`git push -u origin master`), entering your username and password each time. 
+*NOTE* Remote access to GitHub is, by default, via an SSH key (see [here](https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh)). If you do not have key-pair authentication set up from your current machine, this stage will fail when it tries to push the new repository to GitHub. So, you should either have a key-pair setup for the machine you are working on before invoking this setup (highly recommended) or, after this setup fails, change remote access to HTTP using `git remote set-url` (see [here](https://docs.github.com/en/enterprise/2.15/user/articles/changing-a-remotes-url)). The repository can then be pushed to GitHub in the usual way (`git push -u origin master`), entering your username and password each time. 
 
 Now configure the packages you will need (you can add more later) in the 'environment.yml' file and create a conda environment
 


### PR DESCRIPTION
Relating to the issue here #4 , I have added a description in the README. 