### PR TITLE
Fixed readthedocs error

### DIFF
--- a/{{ cookiecutter.project_name.lower().replace(' ', '_') }}/readthedocs.yml
+++ b/{{ cookiecutter.project_name.lower().replace(' ', '_') }}/readthedocs.yml
@@ -4,6 +4,6 @@ python:
    version: 3.8
    install:
       - method: setuptools
-        path: package
+        path: .
 sphinx:
   fail_on_warning: true


### PR DESCRIPTION
Readthedocs couldn't import the package, so versioning and API docs couldn't be built. 

Changed `.readthedocs.yaml` so that setuptools installs from `.` instead of `package`